### PR TITLE
Remote loading of Table and Schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,19 +23,20 @@ A library for working with [Table Schema](http://specs.frictionlessdata.io/table
 
 :construction: This package is pre-release and under heavy development. Please see [DESIGN.md](DESIGN.md) for a detailed overview of our goals, and visit the [issues page](https://github.com/frictionlessdata/tableschema-jl/issues) to contribute and make suggestions. For questions that need to a real time response, reach out via [Gitter](https://gitter.im/frictionlessdata/chat). Thanks! :construction:
 
-# Usage
-
 We aim to make this library compatible with all widely used approaches to work with tabular data in Julia.
 
 Please visit [our wiki](https://github.com/frictionlessdata/datapackage-jl/wiki) for a list of related projects that we are tracking, and contibute use cases there or as enhancement [issues](https://github.com/frictionlessdata/tableschema-jl/issues).
+
+# Usage
 
 See `examples` folder and unit tests in [runtests.jl](test/runtests.jl) for current usage.
 
 ## Table
 
 ```Julia
-filestream = os.open("cities.csv")
-table = Table(filestream)
+using TableSchema
+
+table = Table("cities.csv")
 table.headers
 # ['city', 'location']
 table.read(keyed=True)
@@ -57,10 +58,7 @@ err = table.errors # handle errors
 ## Schema
 
 ```Julia
-using TableSchema
-
-filestream = os.open("schema.json")
-schema = Schema(filestream)
+schema = Schema("schema.json")
 schema.fields
 # <Field1, Field2...>
 err = schema.errors # handle errors
@@ -80,7 +78,7 @@ add_field(schema, field)
 
 ## Installation
 
-:construction: Work In Progress. The following documentation is relevant only after package release.
+:construction: Work In Progress. The following documentation is relevant only after package release. In the interim, please see [datapackage-jl](https://github.com/frictionlessdata/datapackage-jl)
 
 The package use semantic versioning, meaning that major versions could include breaking changes. It is highly recommended to specify a version range in your `REQUIRE` file e.g.:
 

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,1 +1,2 @@
 julia 0.6
+HTTP

--- a/examples/basic.jl
+++ b/examples/basic.jl
@@ -5,10 +5,6 @@ using TableSchema
 import TableSchema: read, is_valid, validate
 
 t = Table()
-source = readcsv("../data/data_types.csv")
-tr = read(t, source) # 5x5 Array{Any,2}
-println( "The length is ", length(tr[:,1]) ) # 5
-println( "Sum of column 2 is ", sum([ row[2] for row in t ]) ) # 51.0
 
 s = Schema("../data/schema_invalid_empty.json")
 if is_valid(s) == false; println("An invalid Schema was found"); end
@@ -17,10 +13,15 @@ s = Schema("../data/schema_valid_missing.json")
 if is_valid(s); println("A valid Schema is ready"); end
 
 t.schema = s
+source = readcsv("../data/data_types.csv")
+tr = read(t, data=source) # 5x5 Array{Any,2}
+println( "The length is ", length(tr[:,1]) ) # 5
+println( "Sum of column 2 is ", sum([ row for row in tr[2] ]) ) # 51.0
+
 if validate(t); println("The table is valid according to the Schema"); end
 
 t2 = Table("../data/data_constraints.csv", s)
 if validate(t2) == false; println("This other table is not valid"); end
 for err in t2.errors
-    println(string(err.field.name, " has error: ", err.message))
+    println(string(err.field.name, " has (expected) error: ", err.message))
 end

--- a/examples/remote.jl
+++ b/examples/remote.jl
@@ -7,7 +7,7 @@ import HTTP: request
 # Either import the functions, or use TableSchema.read(<Table>) in the code
 import TableSchema: read, is_valid, validate
 
-REMOTE_URL = "https://raw.githubusercontent.com/frictionlessdata/tableschema-jl/master/data/data.csv"
+REMOTE_URL = "https://raw.githubusercontent.com/frictionlessdata/tableschema-jl/master/data/data_simple.csv"
 
 println( "Fetching remote data ..." )
 t = Table()

--- a/examples/remote.jl
+++ b/examples/remote.jl
@@ -13,13 +13,15 @@ println( "Fetching remote data ..." )
 t = Table()
 req = request("GET", REMOTE_URL)
 data = readcsv(req.body)
-tr = read(t, data) # Array{Any,2}
+tr = read(t, data=data, cast=false) # Array{Any,2}
 
 column1 = tr[:,1]
 println( "The length is ", length(column1) ) # 3
 println( "Fun cities are ", join([ row for row in column1 ], ",") ) # london,paris,rome
 
-s = Schema("../data/schema_valid_simple.json")
+println( "Fetching remote schema ..." )
+s = Schema("https://raw.githubusercontent.com/frictionlessdata/tableschema-jl/master/data/schema_valid_simple.json")
+
 if is_valid(s); println("A valid Schema is ready"); end
 
 t.schema = s

--- a/src/TableSchema.jl
+++ b/src/TableSchema.jl
@@ -16,6 +16,7 @@ using Base.Iterators: filter
 using Base.Iterators: Repeated, repeated
 
 using JSON
+import HTTP: request
 
 DEFAULT_TYPE = "string"
 DEFAULT_FORMAT = "default"

--- a/src/schema.jl
+++ b/src/schema.jl
@@ -42,8 +42,15 @@ mutable struct Schema
         validate(s, strict)
     end
 
-    Schema(filename::String, strict::Bool=false) =
-        Schema(JSON.parsefile(filename), strict)
+    function Schema(filename::String, strict::Bool=false)
+        if match(r"^https?://", filename) !== nothing
+            req = request("GET", filename)
+            jsondata = JSON.parse(req.body)
+        else
+            jsondata = JSON.parsefile(filename)
+        end
+        Schema(jsondata, strict)
+    end
 
     Schema(strict::Bool=false) =
         Schema(Dict(), strict)

--- a/src/schema.jl
+++ b/src/schema.jl
@@ -42,18 +42,20 @@ mutable struct Schema
         validate(s, strict)
     end
 
-    function Schema(filename::String, strict::Bool=false)
-        if match(r"^https?://", filename) !== nothing
-            req = request("GET", filename)
-            jsondata = JSON.parse(req.body)
-        else
-            jsondata = JSON.parsefile(filename)
-        end
-        Schema(jsondata, strict)
-    end
+    Schema(filename::String, strict::Bool=false) =
+        Schema(fetch_json(filename), strict)
 
     Schema(strict::Bool=false) =
         Schema(Dict(), strict)
+end
+
+function fetch_json(filename::String)
+    if match(r"^https?://", filename) !== nothing
+        req = request("GET", filename)
+        JSON.parse(req.body)
+    else
+        JSON.parsefile(filename)
+    end
 end
 
 function validate(s::Schema, strict::Bool=false)

--- a/src/table.jl
+++ b/src/table.jl
@@ -10,9 +10,8 @@ mutable struct Table
     errors::Array{ConstraintError}
 
     function Table(csvfilename::String, schema::Schema=Schema())
-        m = match(r"http[s]://", csvfilename)
-        if typeof(m) != Void && m.offset == 1
-            throw(ErrorException("Please use a library like Requests to download HTTP resources"))
+        if match(r"^https?://", csvfilename) !== nothing
+            source = read_remote_csv(csvfilename)
         else
             source = readcsv(csvfilename)
         end
@@ -30,6 +29,11 @@ mutable struct Table
     function Table()
         new(Void, [], Schema(), [])
     end
+end
+
+function read_remote_csv(url::String)
+    req = request("GET", url)
+    data = readcsv(req.body)
 end
 
 function get_headers(source::Array)

--- a/test/read.jl
+++ b/test/read.jl
@@ -47,4 +47,15 @@ TABLE_CAST = """id,height,age,name,occupation
         @test typeof(tr[2,1]) == Float64
     end
 
+    @testset "Remote data and schema reading" begin
+        t = Table("https://raw.githubusercontent.com/frictionlessdata/tableschema-jl/master/data/data_types.csv")
+        trs = TableSchema.read(t, cast=false)
+        # check the headers
+        @test length(t.headers) == 5
+        @test t.headers[2] == "height"
+        # validate from remote schema
+        t.schema = Schema("https://raw.githubusercontent.com/frictionlessdata/tableschema-jl/master/data/schema_valid_missing.json")
+        @test validate(t)
+    end
+
 end

--- a/test/read.jl
+++ b/test/read.jl
@@ -20,6 +20,15 @@ TABLE_CAST = """id,height,age,name,occupation
         @test_throws TableValidationException validate(t)
     end
 
+    @testset "Passing an IO buffered file" begin
+        t = Table()
+        t.schema = Schema("data/schema_valid_missing.json")
+        @test TableSchema.is_valid(t.schema)
+        f = readcsv("data/data_types.csv")
+        tr = TableSchema.read(t, data=f)
+        @test validate(t)
+    end
+
     @testset "With schema validation" begin
         s = Schema("data/schema_valid_missing.json")
         t = Table("data/data_types.csv", s)


### PR DESCRIPTION
This is now possible simply by putting in an `http(s)` URL into the constructor.

Adds dependency on the [HTTP.jl library](https://github.com/JuliaWeb/HTTP.jl)